### PR TITLE
stores processed image as a b64string rather than array string

### DIFF
--- a/final.py
+++ b/final.py
@@ -451,7 +451,10 @@ def image_processed_upload():
 
     processed_image, time_to_process = process_image(image_string,
                                                      process_type)
-    processed_image = str(processed_image)
+    processed_image_b64bytes = base64.b64encode(processed_image)
+    # makes array into b64string
+    processed_image_b64string = processed_image_b64bytes.decode("UTF-8")
+    processed_image = processed_image_b64string
     time_to_process = str(time_to_process)
     process_time = datetime.now()
     process_info = {image_no_format: processed_image,


### PR DESCRIPTION
fixes #78 
@sputney13 Would you be able to check that I interpreted what you were doing correctly? The image processing function outputs are arrays, and it looked like the array was being stored as a string in the dictionary under "image_processed_upload()". I just added a few lines so that the base64string is stored instead of the array string. 