### PR TITLE
Sep52/zip-problems

### DIFF
--- a/final.py
+++ b/final.py
@@ -17,7 +17,7 @@ import logging
 connect("mongodb://sputney13:sputney13@ds161901.mlab.com:61901/bme590final")
 app = Flask(__name__)
 
-logging.basicConfig(filename="hrss.log", filemode='w', level=logging.INFO)
+logging.basicConfig(filename="final.log", filemode='w', level=logging.INFO)
 
 
 class ImageDB(MongoModel):
@@ -173,8 +173,14 @@ def image_parser(file_list):
     for file in file_list:
         if file.endswith('.zip'):
             image_names = unzip_folder(file)
+
             file_list.remove(file)
             file_list.append(image_names)
+    for image in file_list:
+        if type(image) is list:
+            for contents in image:
+                file_list.append(contents)
+            file_list.remove(image)
     for image in file_list:
         if image.endswith('.jpg') or image.endswith('.png') or image\
                 .endswith('.tiff'):

--- a/gui.py
+++ b/gui.py
@@ -204,20 +204,22 @@ class App3(QMainWindow):
         label.setMinimumSize(250, 40)
 
     def scroll_down_menu(self):
-        global global_image_dict
         global global_user_email
+        uploaded_images = client.get_uploaded_images(global_user_email)
         label = QLabel("List of Images", self)
         combo = QComboBox(self)
-        for i in global_image_name:
+        for i in uploaded_images:
             combo.addItem(i)
         combo.move(250, 150)
         label.setGeometry(150, 20, 640, 280)
         combo.activated[str].connect(self.on_activated)
 
     def on_activated(self, name):
-        global global_user_email
+        global global_image_name
         global global_selected_name
-        global_selected_name = name
+        for i in global_image_name:
+            if name in i:
+                global_selected_name = name
         print(global_selected_name)
 
     def button_upload(self):
@@ -311,7 +313,7 @@ class App4(QMainWindow):
         global global_user_email
         global global_process_type
         global global_selected_name
-        image_strip = global_selected_namegi.split('/')[-1]
+        image_strip = global_selected_name.split('/')[-1]
         image_name = image_strip.split('.')[0]
         global_process_type = "HistogramEqualization"
         print(global_user_email)
@@ -410,13 +412,13 @@ class App5(QMainWindow):
         global global_user_email
         global global_process_type
         global global_selected_name
-        image_strip = global_process_type.split('/')[-1]
+        image_strip = global_selected_name.split('/')[-1]
         image_name = image_strip.split('.')[0]
         processed_images = client.get_processed_image(
             global_user_email, image_name, global_process_type)
         label = QLabel(self)
         data = QByteArray.fromBase64(
-            processed_images.get(global_selected_name))
+            processed_images[image_name])
         pixmap = QPixmap()
         if pixmap.loadFromData(data, "PNG"):
             self.label.setPixmap(pixmap)


### PR DESCRIPTION
@EricaSkerrett The GUI wasn't working with .zip files, so I was troubleshooting it. I resolved an issue where the zip returned a list inside a list, but now the problem is that when the file is un-zipped, it gives image names of, for example, 'test_zip/capy.jpg', which is fine, except it doesn't create a folder called test_zip, so the image encoder cannot access it. It seems like it might be creating that folder WITHIN the zip file which also doesn't really work. Can you check this out and see if you can fix it?

Also do we really need a get request for the histogram or was that function intended to go inside the gui code?

@RoujiaW Still having the same issues with uploading the processed image... I made some changes, maybe you can make even more. Also, is the image viewer only worker for JPG files currently? Whenever I upload non-JPG's, it won't display the image.