### PR TITLE
fixes png issue

### DIFF
--- a/final.py
+++ b/final.py
@@ -526,9 +526,9 @@ def image_processed_upload():
     processed_image, time_to_process = process_image(image_string,
                                                      process_type)
 
-    img = Image.fromarray(processed_image, 'RGB')
+    img = Image.fromarray(processed_image)  # , 'RGB')
     buffer = io.BytesIO()
-    img.save(buffer, format="JPEG")
+    img.save(buffer, format='png')
     myimage = buffer.getvalue()
     bytes = base64.b64encode(myimage)
     processed_image = bytes.decode()  # basestring


### PR DESCRIPTION
The issue was with the line `img = Image.fromarray(array, 'RGB')`

RGB, I think, is jpeg-specific so removing it `img = Image.fromarray(array)` allows us to processes the PNG array.

JPEGs can run through this way as well, but the image will need to be saved as a "PNG". If we wanted to keep JPEGs as JPEGs, I'd just need to add an if statement to check the format. 
